### PR TITLE
validateCVC param return bug

### DIFF
--- a/src/card.js.coffee
+++ b/src/card.js.coffee
@@ -108,7 +108,7 @@ Conekta.card.getBrand = (number)->
   null
 
 Conekta.card.validateCVC = (cvc)->
-  (typeof cvc == 'number' and cvc >=0 and cvc < 10000) or (typeof cvc == 'string' and cvc.match(/^[\d]{3,4}$/) != null)
+  (cvc = ('' + cvc)) and (typeof cvc == 'string' and cvc.match(/^[\d]{3,4}$/) != null)
 
 Conekta.card.validateExpMonth = (exp_month)->
   month = parseMonth(exp_month)


### PR DESCRIPTION
The current method returns true if a CVC is a number between 0 < 10000 (I don't know why) and will not even go through the match expression.

I corrected by parsing cvc param to string AND THEN run the match expression on the subject.